### PR TITLE
Re-export the firebase module

### DIFF
--- a/Examples/FireBaseUI/FireBaseUI.swift
+++ b/Examples/FireBaseUI/FireBaseUI.swift
@@ -3,7 +3,6 @@
 import SwiftWin32
 import Foundation
 
-import firebase
 import FirebaseCore
 import FirebaseAuth
 

--- a/Examples/FireBaseUI/FireBaseUIViewController.swift
+++ b/Examples/FireBaseUI/FireBaseUIViewController.swift
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
-import firebase
 import FirebaseCore
 import FirebaseAuth
 import SwiftWin32

--- a/Sources/FirebaseAuth/FIRAuthTokenResult.swift
+++ b/Sources/FirebaseAuth/FIRAuthTokenResult.swift
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
+@_exported
 import firebase
 
 import Foundation

--- a/Sources/FirebaseAuth/FirebaseAuth+Swift.swift
+++ b/Sources/FirebaseAuth/FirebaseAuth+Swift.swift
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
+@_exported
 import firebase
 import FirebaseCore
 

--- a/Sources/FirebaseAuth/FirebaseAuthResult+Swift.swift
+++ b/Sources/FirebaseAuth/FirebaseAuthResult+Swift.swift
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
+@_exported
 import firebase
 
 public typealias AuthDataResult = UnsafeMutablePointer<firebase.auth.AuthResult>

--- a/Sources/FirebaseAuth/FirebaseUser+Swift.swift
+++ b/Sources/FirebaseAuth/FirebaseUser+Swift.swift
@@ -3,6 +3,7 @@
 import CxxStdlib
 import Foundation
 
+@_exported
 import firebase
 import FirebaseCore
 

--- a/Sources/FirebaseCore/FirebaseApp+Swift.swift
+++ b/Sources/FirebaseCore/FirebaseApp+Swift.swift
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
+@_exported
 import firebase
 
 public typealias FirebaseApp = UnsafeMutablePointer<firebase.App>

--- a/Sources/FirebaseCore/FirebaseConfiguration.swift
+++ b/Sources/FirebaseCore/FirebaseConfiguration.swift
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
+@_exported
 import firebase
 
 public class FirebaseConfiguration {

--- a/Sources/FirebaseCore/FirebaseLogging+Swift.swift
+++ b/Sources/FirebaseCore/FirebaseLogging+Swift.swift
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
+@_exported
 import firebase
 
 public typealias FirebaseLoggerLevel = firebase.LogLevel

--- a/Sources/FirebaseCore/FirebaseOptions+Swift.swift
+++ b/Sources/FirebaseCore/FirebaseOptions+Swift.swift
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
+@_exported
 import firebase
 
 import Foundation


### PR DESCRIPTION
This removes the need to explicitly import the `firebase` (C++) module when using the Swift interfaces.  This makes the interface easier to use in clients.