### PR TITLE
FirebaseAuth: rename `ActionCodeOperation` enumerations

### DIFF
--- a/Sources/FirebaseAuth/FIRActionCodeOperation.swift
+++ b/Sources/FirebaseAuth/FIRActionCodeOperation.swift
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 public enum ActionCodeOperation: Int {
-  case FIRActionCodeOperationUnknown
-  case FIRActionCodeOperationPasswordReset
-  case FIRActionCodeOperationVerifyEmail
-  case FIRActionCodeOperationRecoverEmail
-  case FIRActionCodeOperationEmailLink
-  case FIRActionCodeOperationVerifyAndChangeEmail
-  case FIRActionCodeOperationRevertSecondFactorAddition
+  case unknown
+  case passwordReset
+  case verifyEmail
+  case recoverEmail
+  case emailLink
+  case verifyAndChangeEmail
+  case revertSecondFactorAddition
 }


### PR DESCRIPTION
These should be prefix stripped and lowercased as per the omit-needless-words approach.