### PR TITLE
Let's ignore copied in files in the third_party directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.sw?
 .build/
 .vscode/
+third_party/
 Examples/FireBaseUI/Resources/google-services-desktop.json


### PR DESCRIPTION
I saw a huge number of changes in my local when I was setting the repo up, seems like we should ignore the `third_party` folder. 