### PR TITLE
Updating README to be a bit clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ As of 2023-08-10, the Firebase SDK requires some changes to support the Swift/C+
 
 0. Make sure you have the right Swift toolchain installed, currently this repo requires at least https://download.swift.org/development/windows10/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a-windows10.exe to build.
 1. Download the lastest build of the Firebase C++ SDK from https://github.com/thebrowsercompany/firebase-cpp-sdk/tags
-2. Run `mkdir third_party\firebase-development` to create the folder where we will extract the Firebase C++ SDK release that was just downloaded
-3. Extract the Firebase C++ SDK release into the `third_party\firebase-development` folder that was just created.
+2. Run `md third_party\firebase-development` to create the directory where we will extract the Firebase C++ SDK release that was just downloaded
+3. Extract the Firebase C++ SDK release into the `third_party\firebase-development` directory that was just created.
 4. Modify the `Examples\FireBaseUI\Resources\google-services.json` file to include the correct values from Firebase.
 
 ### Building

--- a/README.md
+++ b/README.md
@@ -2,17 +2,24 @@
 
 Swift bindings for [firebase-cpp-sdk](https://github.com/firebase/firebase-cpp-sdk), loosely modelled after the iOS APIs.  It serves as both exploration of the C++ Interop as well as a means of using Firebase on Windows from Swift.
 
-### Requirements
+## Requirements
 
 The Swift interface to Firebase is built upon the [Firebase C++ SDK](https://github.com/firebase/firebase-cpp-sdk).  As a result, the package requires that the C++ SDK is available and distributed to the clients.  The package expects that the firebase SDK is present in the root of the source tree under `third_party/firebase-development/usr`.
 
-As of 2023-08-10, the Firebase SDK requires some changes to support the Swift/C++ interop.  The changes for this are available [here](patches/0001-Add-a-couple-of-workarounds-for-Swift-on-Windows.patch).  This has sent upstream as [firebase/firebase-cpp-sdk#1414](https://github.com/firebase/firebase-cpp-sdk/pull/1414).  You can currently use a prebuilt version of the C++ SDK with this patch from [thebrowsercompany/firebase-cpp-sdk](https://github.com/thebrowsercompany/firebase-cpp-sdk) release [20230807.0](https://github.com/thebrowsercompany/firebase-cpp-sdk/releases/tag/20230807.0).
+As of 2023-08-10, the Firebase SDK requires some changes to support the Swift/C++ interop.  The changes for this are available [here](patches/0001-Add-a-couple-of-workarounds-for-Swift-on-Windows.patch).  This has sent upstream as [firebase/firebase-cpp-sdk#1414](https://github.com/firebase/firebase-cpp-sdk/pull/1414).
 
-The `google-services.json` file must be updated with the proper values in place of the placeholder values.
+## Setup
+
+### Prerequisites
+
+1. Download the lastest build of the Firebase C++ SDK from https://github.com/thebrowsercompany/firebase-cpp-sdk/tags
+2. Run `mkdir third_party\firebase-development` to create the folder where we will extract the Firebase C++ SDK release that was just downloaded
+3. Extract the Firebase C++ SDK release into the `third_party\firebase-development` folder that was just created.
+4. Modify the `Examples\FireBaseUI\Resources\google-services.json` file to include the correct values from Firebase.
 
 ### Building
 
-Assuming a build of firebase is available in the top level under `third_party/firebase-development/usr`, the package should build as a standard SPM package using:
+Assuming a build of firebase is available in the top level under `third_party\firebase-development\usr`, the package should build as a standard SPM package using:
 ```powershell
 swift build
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ As of 2023-08-10, the Firebase SDK requires some changes to support the Swift/C+
 
 ### Prerequisites
 
+0. Make sure you have the right Swift toolchain installed, currently this repo requires at least https://download.swift.org/development/windows10/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a-windows10.exe to build.
 1. Download the lastest build of the Firebase C++ SDK from https://github.com/thebrowsercompany/firebase-cpp-sdk/tags
 2. Run `mkdir third_party\firebase-development` to create the folder where we will extract the Firebase C++ SDK release that was just downloaded
 3. Extract the Firebase C++ SDK release into the `third_party\firebase-development` folder that was just created.


### PR DESCRIPTION
While the existing README contained most of the information needed to setup the repo, I found it could be clearer if we broke down the steps for setup into a list explicitly so people can easily hone in on what is required to build when they pick up this repo. I also made a few minor edits to heading size and moved content around a tiny bit.