### PR TITLE
Create a simple script to copy files and run the app

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -1,0 +1,11 @@
+# Ensures that we copy the right things into the build folder when we run
+# Ideally this would be done with an SPM plugin, but they don't work on
+# Windows yet, so here we are.
+Write-Output "Copying Info.plist..."
+Copy-Item Examples\FireBaseUI\Info.plist .build\debug\
+
+Write-Output "Copying manifest..."
+Copy-Item Examples\FireBaseUI\FireBaseUI.exe.manifest .build\debug\
+
+Write-Output "Running application"
+swift run -Xswiftc "-I${env:SDKROOT}\usr\lib\swift_static\windows"


### PR DESCRIPTION
We need to ensure that files get copied to the right place before running the application. Ideally SPM would do this with a plugin, but they don't work on Windows right now. This just gives us a tiny speed up in our local build loop.