### PR TITLE
Avoid use of experimental features

### DIFF
--- a/Sources/FirebaseAuth/FirebaseAuth+Swift.swift
+++ b/Sources/FirebaseAuth/FirebaseAuth+Swift.swift
@@ -2,6 +2,7 @@
 
 @_exported
 import firebase
+@_spi(Error)
 import FirebaseCore
 
 import CxxShim

--- a/Sources/FirebaseAuth/FirebaseUser+Swift.swift
+++ b/Sources/FirebaseAuth/FirebaseUser+Swift.swift
@@ -5,6 +5,7 @@ import Foundation
 
 @_exported
 import firebase
+@_spi(Error)
 import FirebaseCore
 
 public typealias User = firebase.auth.User

--- a/Sources/FirebaseCore/FirebaseError.swift
+++ b/Sources/FirebaseCore/FirebaseError.swift
@@ -4,7 +4,8 @@ public struct FirebaseError: Error {
   public let code: CInt
   public let message: String
 
-  package init(code: CInt, message: String) {
+  @_spi(Error)
+  public init(code: CInt, message: String) {
     self.code = code
     self.message = message
   }


### PR DESCRIPTION
Avoid the use of `package` visibility as this is not yet generally available and triggers an assertion failure in some cases.  Mark the previously package visibility initialiser as an Error SPI.