### PR TITLE
FireBaseUI: support non-SPM builds

### DIFF
--- a/Examples/FireBaseUI/FireBaseUI.swift
+++ b/Examples/FireBaseUI/FireBaseUI.swift
@@ -8,7 +8,11 @@ import FirebaseAuth
 
 extension Foundation.Bundle {
   internal static var resources: URL {
+#if SWIFT_PACKAGE
     Bundle.module.bundleURL.appendingPathComponent("Resources")
+#else
+    Bundle.main.bundleURL.appendingPathComponent("Resources")
+#endif
   }
 }
 


### PR DESCRIPTION
`Bundle.module` is only available with SPM builds, support non-SPM builds by falling back to `Bundle.main`.