### PR TITLE
GHA: bump the firebase SDK snapshot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4 # v1.1.1
         with:
           repo: thebrowsercompany/firebase-cpp-sdk
-          version: tags/20230823.0
+          version: tags/20230828.0
           file: firebase-windows-amd64.zip
 
       - run: Expand-Archive -Path firebase-windows-amd64.zip -DestinationPath third_party/firebase-development

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4 # v1.1.1
         with:
           repo: thebrowsercompany/firebase-cpp-sdk
-          version: tags/20230807.0
+          version: tags/20230823.0
           file: firebase-windows-amd64.zip
 
       - run: Expand-Archive -Path firebase-windows-amd64.zip -DestinationPath third_party/firebase-development


### PR DESCRIPTION
Update to the 20230823 snapshot to get additional fixes for FireStore.