### PR TITLE
Add code to download the Firebase CPP SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,22 @@ set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
 include(FetchContent)
 
+# Download The Firebase CPP SDK and extract it to disk
+set(FIREBASE_CPP_SDK_VERSION "20230828.0")
+
+message(${CMAKE_SOURCE_DIR})
+
+include(FetchContent)
+FetchContent_Declare(
+    firebase_sdk
+    URL "https://github.com/thebrowsercompany/firebase-cpp-sdk/releases/download/${FIREBASE_CPP_SDK_VERSION}/firebase-windows-amd64.zip"
+    DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/downloads
+    SOURCE_DIR "${CMAKE_SOURCE_DIR}/third_party/firebase-development/usr"
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+)
+
+FetchContent_MakeAvailable(firebase_sdk)
+
 add_library(firebase INTERFACE)
 target_compile_options(firebase INTERFACE
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -DINTERNAL_EXPERIMENTAL>")


### PR DESCRIPTION
I was getting this repo re-setup and I sort of forgot where things were and realized that I now know enough about CMake to add a little snippet which can download the CPP SDK and set it up in the right place. This can make it easier to iterate as we introduce more changes to the CPP SDK when we need to expose more surface areas. 

This will breakdown once we start having different architectures we need to include, but it seems like a small nice thing to have for the time being.