### PR TITLE
FirebaseCore: change signature of `FirebaseOptions.defaultOptions()`

### DIFF
--- a/Sources/FirebaseCore/FirebaseOptions+Swift.swift
+++ b/Sources/FirebaseCore/FirebaseOptions+Swift.swift
@@ -26,8 +26,11 @@ extension firebase.AppOptions: CustomDebugStringConvertible {
 }
 
 extension FirebaseOptions {
-  public static func defaultOptions() -> FirebaseOptions? {
-    firebase.AppOptions.LoadDefault(nil)
+  public static func defaultOptions() -> FirebaseOptions {
+    guard let options = firebase.AppOptions.LoadDefault(nil) else {
+      fatalError("unable to deserialise firebase options")
+    }
+    return options
   }
 
   public init?(contentsOfFile plistPath: String) {


### PR DESCRIPTION
This method returns a non-optional value in ObjC, follow suit and ensure that the value is unwrapped when we return to make the library source compatible.