### PR TITLE
Expose User.reauthenticate method

### DIFF
--- a/Sources/FirebaseAuth/FirebaseEmailAuthProvider.swift
+++ b/Sources/FirebaseAuth/FirebaseEmailAuthProvider.swift
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+@_exported
+import firebase
+@_spi(FirebaseInternal)
+import FirebaseCore
+
+import CxxShim
+import Foundation
+
+public typealias EmailAuthProvider = UnsafeMutablePointer<firebase.auth.EmailAuthProvider>
+public typealias Credential = UnsafeMutablePointer<firebase.auth.Credential>
+
+extension EmailAuthProvider {
+    func credential(withEmail email: String, password: String) -> Credential {
+        GetCredential(email, password)
+    }
+}

--- a/Sources/FirebaseAuth/FirebaseUser+Swift.swift
+++ b/Sources/FirebaseAuth/FirebaseUser+Swift.swift
@@ -9,6 +9,7 @@ import firebase
 import FirebaseCore
 
 public typealias User = firebase.auth.User
+public typealias AuthResult = firebase.auth.AuthResult
 
 public protocol UserInfo {
   var providerID: String { get }
@@ -84,10 +85,26 @@ extension User {
     }
   }
 
-  // public mutating func reauthenticate(with credential: AuthCredential) async throws
-  //     -> AuthResult {
-  //   fatalError("\(#function) not yet implemented")
-  // }
+  public mutating func reauthenticate(with credential: Credential) async throws
+      -> AuthResult {
+      typealias Promise = CheckedContinuation<firebase.auth.AuthResult, any Error>
+      return try await withCheckedThrowingContinuation { (continuation: Promise) in
+        let future = self.ReauthenticateAndRetrieveData(credential)
+        withUnsafePointer(to: continuation) { continuation in
+          future.OnCompletion_SwiftWorkaround({ future, pvContinuation in
+            let pContinuation = pvContinuation?.assumingMemoryBound(to: Promise.self)
+            if future.pointee.error() == 0 {
+              pContinuation.pointee.resume(returning: future.pointee.__resultUnsafe().pointee)
+            } else {
+              let code = future.pointee.error()
+              let message = String(cString: future.pointee.__error_messageUnsafe()!)
+              pContinuation.pointee.resume(throwing: FirebaseError(code: code, message: message))
+            }
+          }, UnsafeMutableRawPointer(mutating: continuation))
+        }
+        future.Wait(firebase.FutureBase.kWaitTimeoutInfinite)
+      }
+  }
 
   // -reauthenticateWithProvider:UIDelegate:completion:
 


### PR DESCRIPTION
This implements one of the missing methods - `User.reauthenticate()` in the `swift-firebase` API.

The implementation is pretty standard wrapper.

Additionally `EmailAuthProvider`, `Credential`, `AuthResult` as very basic typealiases, so that they can be passed around in the reauthentication calls we want to do in Arc.

On top of that `EmailAuthProvider.credential` is provided to build the `Credential` in a way that is compatible with macos swift version of this library.